### PR TITLE
WriteStream closed after data are merged

### DIFF
--- a/chunkedUpload.js
+++ b/chunkedUpload.js
@@ -39,6 +39,7 @@ class ChunkedUpload {
 				console.log('Cant find', i);
 			}
 		}
+		mergedFile.end()
 	}
 
 	get(req, callback) {


### PR DESCRIPTION
File is unreadable as long as the server is running. When the server terminates, the file is accesable. To unlock the file after the writing is finished, I added `mergedFile.end()`.